### PR TITLE
Avoid SocketException scenario caused due to incompatibility of using…

### DIFF
--- a/SocketEngine/UdpSocketListener.cs
+++ b/SocketEngine/UdpSocketListener.cs
@@ -35,8 +35,8 @@ namespace SuperSocket.SocketEngine
                 m_ListenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                 m_ListenSocket.Bind(this.EndPoint);
 
-                //Mono doesn't support it
-                if (Platform.SupportSocketIOControlByCodeEnum)
+                // Mono doesn't support it as no ioctl call in Mono.Unix.Native
+                if (Platform.SupportSocketIOControlByCodeEnum && !Platform.isMono)
                 {
                     uint IOC_IN = 0x80000000;
                     uint IOC_VENDOR = 0x18000000;


### PR DESCRIPTION
… ioctl system calls under a Mono environment.

Trying to run the Udp listener it jsut got exception when it tried to call system to set a control code. I can understand it could be fixed using or including a native wrapper of these system calls. Obviously , there was a warning comment was written on the table but it just warns but not avoid the scenario using code that's why Platform.IsMono would help us in such fix.