### PR TITLE
Add abstraction for Socket and SocketAsyncEventArgs

### DIFF
--- a/Common/BufferManager.cs
+++ b/Common/BufferManager.cs
@@ -20,6 +20,28 @@ namespace SuperSocket.Common
         int m_bufferSize;
 
         /// <summary>
+        /// Get the buffer
+        /// </summary>
+        public byte[] Buffer
+        {
+            get
+            {
+                return m_buffer;
+            }
+        }
+
+        /// <summary>
+        /// Get the buffer
+        /// </summary>
+        public int BufferSize
+        {
+            get
+            {
+                return m_bufferSize;
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BufferManager"/> class.
         /// </summary>
         /// <param name="totalBytes">The total bytes.</param>
@@ -44,35 +66,35 @@ namespace SuperSocket.Common
         /// <summary>
         /// Assigns a buffer from the buffer pool to the specified SocketAsyncEventArgs object
         /// </summary>
-        /// <returns>true if the buffer was successfully set, else false</returns>
-        public bool SetBuffer(SocketAsyncEventArgs args)
+        /// <returns>A Tuple where Item1 is true if the buffer should be set, else false.
+        /// If Item1 is true then Item2 has the new offset, else 0.
+        /// </returns>
+        public Tuple<bool, int> SetBuffer()
         {
-
+            int offset;
             if (m_freeIndexPool.Count > 0)
             {
-                args.SetBuffer(m_buffer, m_freeIndexPool.Pop(), m_bufferSize);
+                offset = m_freeIndexPool.Pop();
             }
             else
             {
                 if ((m_numBytes - m_bufferSize) < m_currentIndex)
                 {
-                    return false;
+                    return new Tuple<bool, int>(false, 0);
                 }
-                args.SetBuffer(m_buffer, m_currentIndex, m_bufferSize);
+                offset = m_currentIndex;
                 m_currentIndex += m_bufferSize;
             }
-            return true;
+            return new Tuple<bool, int>(true, offset);
         }
 
         /// <summary>
-        /// Removes the buffer from a SocketAsyncEventArg object.  This frees the buffer back to the 
+        /// Removes the buffer from a SocketAsyncEventArg object.  This frees the buffer back to the
         /// buffer pool
         /// </summary>
-        public void FreeBuffer(SocketAsyncEventArgs args)
+        public void FreeBuffer(int offset)
         {
-            m_freeIndexPool.Push(args.Offset);
-            args.SetBuffer(null, 0, 0);
+            m_freeIndexPool.Push(offset);
         }
-
     }
 }

--- a/Common/SuperSocket.Common.Net45.csproj
+++ b/Common/SuperSocket.Common.Net45.csproj
@@ -95,7 +95,6 @@
     <Compile Include="SearchMarkState.cs" />
     <Compile Include="SendingQueue.cs" />
     <Compile Include="SmartPool.cs" />
-    <Compile Include="SocketEx.cs" />
     <Compile Include="StringExtension.cs" />
     <Compile Include="StringExtension.NET4.cs" />
     <Compile Include="TheadPoolEx.cs" />

--- a/Protocols/WebSocket/WebSocketServer.cs
+++ b/Protocols/WebSocket/WebSocketServer.cs
@@ -17,6 +17,7 @@ using SuperSocket.SocketBase;
 using SuperSocket.SocketBase.Command;
 using SuperSocket.SocketBase.Config;
 using SuperSocket.SocketBase.Protocol;
+using SuperSocket.SocketBase.Sockets;
 using SuperSocket.WebSocket.Command;
 using SuperSocket.WebSocket.Config;
 using SuperSocket.WebSocket.Protocol;
@@ -105,8 +106,9 @@ namespace SuperSocket.WebSocket
         /// Initializes a new instance of the <see cref="WebSocketServer&lt;TWebSocketSession&gt;"/> class.
         /// </summary>
         /// <param name="subProtocols">The sub protocols.</param>
-        public WebSocketServer(IEnumerable<ISubProtocol<TWebSocketSession>> subProtocols)
-            : this()
+        /// <param name="socketFactory"></param>
+        public WebSocketServer(IEnumerable<ISubProtocol<TWebSocketSession>> subProtocols, ISocketFactory socketFactory = null)
+            : this(socketFactory)
         {
             if (!subProtocols.Any())
                 return;
@@ -133,8 +135,8 @@ namespace SuperSocket.WebSocket
         /// <summary>
         /// Initializes a new instance of the <see cref="WebSocketServer&lt;TWebSocketSession&gt;"/> class.
         /// </summary>
-        public WebSocketServer()
-            : base(new WebSocketProtocol())
+        public WebSocketServer(ISocketFactory socketFactory = null)
+            : base(new WebSocketProtocol(), socketFactory)
         {
 
         }

--- a/SocketBase/AppServer.cs
+++ b/SocketBase/AppServer.cs
@@ -15,6 +15,7 @@ using SuperSocket.SocketBase.Command;
 using SuperSocket.SocketBase.Config;
 using SuperSocket.SocketBase.Protocol;
 using SuperSocket.SocketBase.Security;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketBase
 {
@@ -36,8 +37,9 @@ namespace SuperSocket.SocketBase
         /// Initializes a new instance of the <see cref="AppServer"/> class.
         /// </summary>
         /// <param name="receiveFilterFactory">The Receive filter factory.</param>
-        public AppServer(IReceiveFilterFactory<StringRequestInfo> receiveFilterFactory)
-            : base(receiveFilterFactory)
+        /// <param name="socketFactory">The socket factory.</param>
+        public AppServer(IReceiveFilterFactory<StringRequestInfo> receiveFilterFactory, ISocketFactory socketFactory = null)
+            : base(receiveFilterFactory, socketFactory)
         {
 
         }
@@ -63,8 +65,9 @@ namespace SuperSocket.SocketBase
         /// Initializes a new instance of the <see cref="AppServer&lt;TAppSession&gt;"/> class.
         /// </summary>
         /// <param name="receiveFilterFactory">The Receive filter factory.</param>
-        public AppServer(IReceiveFilterFactory<StringRequestInfo> receiveFilterFactory)
-            : base(receiveFilterFactory)
+        /// <param name="socketFactory">The socket factory.</param>
+        public AppServer(IReceiveFilterFactory<StringRequestInfo> receiveFilterFactory, ISocketFactory socketFactory)
+            : base(receiveFilterFactory, socketFactory)
         {
 
         }
@@ -98,8 +101,9 @@ namespace SuperSocket.SocketBase
         /// Initializes a new instance of the <see cref="AppServer&lt;TAppSession, TRequestInfo&gt;"/> class.
         /// </summary>
         /// <param name="protocol">The protocol.</param>
-        protected AppServer(IReceiveFilterFactory<TRequestInfo> protocol)
-            : base(protocol)
+        /// <param name="socketFactory">The socket factory.</param>
+        protected AppServer(IReceiveFilterFactory<TRequestInfo> protocol, ISocketFactory socketFactory = null)
+            : base(protocol, socketFactory)
         {
    
         }

--- a/SocketBase/AppServerBase.cs
+++ b/SocketBase/AppServerBase.cs
@@ -16,6 +16,7 @@ using SuperSocket.SocketBase.Metadata;
 using SuperSocket.SocketBase.Protocol;
 using SuperSocket.SocketBase.Provider;
 using SuperSocket.SocketBase.Security;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketBase
 {
@@ -81,6 +82,14 @@ namespace SuperSocket.SocketBase
         {
             get { return this.ReceiveFilterFactory; }
         }
+
+        /// <summary>
+        /// Gets or sets the socket factory.
+        /// </summary>
+        /// <value>
+        /// The socket factory.
+        /// </value>
+        public virtual ISocketFactory SocketFactory { get; protected set; }
 
         private List<ICommandLoader<ICommand<TAppSession, TRequestInfo>>> m_CommandLoaders = new List<ICommandLoader<ICommand<TAppSession, TRequestInfo>>>();
 
@@ -175,9 +184,11 @@ namespace SuperSocket.SocketBase
         /// Initializes a new instance of the <see cref="AppServerBase&lt;TAppSession, TRequestInfo&gt;"/> class.
         /// </summary>
         /// <param name="receiveFilterFactory">The Receive filter factory.</param>
-        public AppServerBase(IReceiveFilterFactory<TRequestInfo> receiveFilterFactory)
+        /// <param name="socketFactory"></param>
+        public AppServerBase(IReceiveFilterFactory<TRequestInfo> receiveFilterFactory, ISocketFactory socketFactory = null)
         {
             this.ReceiveFilterFactory = receiveFilterFactory;
+            this.SocketFactory = socketFactory ?? new PassthroughSocketFactory();
         }
 
         /// <summary>

--- a/SocketBase/IAppServer.cs
+++ b/SocketBase/IAppServer.cs
@@ -12,6 +12,7 @@ using SuperSocket.SocketBase.Config;
 using SuperSocket.SocketBase.Logging;
 using SuperSocket.SocketBase.Protocol;
 using SuperSocket.SocketBase.Provider;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketBase
 {
@@ -41,6 +42,11 @@ namespace SuperSocket.SocketBase
         /// Gets the Receive filter factory.
         /// </summary>
         object ReceiveFilterFactory { get; }
+
+        /// <summary>
+        /// Gets the socket factory.
+        /// </summary>
+        ISocketFactory SocketFactory { get; }
 
         /// <summary>
         /// Gets the certificate of current server.

--- a/SocketBase/ISocketSession.cs
+++ b/SocketBase/ISocketSession.cs
@@ -5,8 +5,8 @@ using System.Text;
 using System.IO;
 using System.Net;
 using System.Security.Authentication;
-using System.Net.Sockets;
 using SuperSocket.SocketBase.Command;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketBase
 {
@@ -104,7 +104,7 @@ namespace SuperSocket.SocketBase
         /// <summary>
         /// Gets the client socket.
         /// </summary>
-        Socket Client { get; }
+        ISocket Client { get; }
 
         /// <summary>
         /// Gets the local listening endpoint.
@@ -128,7 +128,6 @@ namespace SuperSocket.SocketBase
         /// Gets the app session assosiated with this socket session.
         /// </summary>
         IAppSession AppSession { get; }
-
 
         /// <summary>
         /// Gets the original receive buffer offset.

--- a/SocketBase/Sockets/ISocket.cs
+++ b/SocketBase/Sockets/ISocket.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+namespace SuperSocket.SocketBase.Sockets
+{
+    /// <summary>
+    /// Socket interface
+    /// </summary>
+    public interface ISocket
+    {
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        bool Connected { get; }
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        bool ExclusiveAddressUse { get; set; }
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        EndPoint LocalEndPoint { get; }
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        bool NoDelay { get; set; }
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        int ReceiveBufferSize { get; set; }
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        EndPoint RemoteEndPoint { get; }
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        int SendBufferSize { get; set; }
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        int SendTimeout { get; set; }
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="e"></param>
+        bool AcceptAsync(ISocketAsyncEventArgs e);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="remoteEP"></param>
+        /// <param name="callback"></param>
+        /// <param name="state"></param>
+        IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="localEP"></param>
+        void Bind(EndPoint localEP);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        void Close();
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="timeout"></param>
+        void Close(int timeout);
+
+        /// <summary>
+        /// Creates a new stream
+        /// </summary>
+        /// <returns></returns>
+        Stream CreateStream();
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="asyncResult"></param>
+        void EndConnect(IAsyncResult asyncResult);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="ioControlCode"></param>
+        /// <param name="optionInValue"></param>
+        /// <param name="optionOutValue"></param>
+        int IOControl(int ioControlCode, byte[] optionInValue, byte[] optionOutValue);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="ioControlCode"></param>
+        /// <param name="optionInValue"></param>
+        /// <param name="optionOutValue"></param>
+        int IOControl(IOControlCode ioControlCode, byte[] optionInValue, byte[] optionOutValue);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="backlog"></param>
+        void Listen(int backlog);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="e"></param>
+        bool ReceiveAsync(ISocketAsyncEventArgs e);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="e"></param>
+        bool ReceiveFromAsync(ISocketAsyncEventArgs e);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffer"></param>
+        int Send(byte[] buffer);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="size"></param>
+        /// <param name="socketFlags"></param>
+        int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="size"></param>
+        /// <param name="socketFlags"></param>
+        /// <param name="errorCode"></param>
+        int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="size"></param>
+        /// <param name="socketFlags"></param>
+        int Send(byte[] buffer, int size, SocketFlags socketFlags);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="socketFlags"></param>
+        int Send(byte[] buffer, SocketFlags socketFlags);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffers"></param>
+        int Send(IList<ArraySegment<byte>> buffers);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffers"></param>
+        /// <param name="socketFlags"></param>
+        int Send(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffers"></param>
+        /// <param name="socketFlags"></param>
+        /// <param name="socketError"></param>
+        int Send(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out SocketError socketError);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="e"></param>
+        bool SendAsync(ISocketAsyncEventArgs e);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="size"></param>
+        /// <param name="socketFlags"></param>
+        /// <param name="remoteEP"></param>
+        int SendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="e"></param>
+        bool SendToAsync(ISocketAsyncEventArgs e);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="optionLevel"></param>
+        /// <param name="optionName"></param>
+        /// <param name="optionValue"></param>
+        void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, bool optionValue);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="optionLevel"></param>
+        /// <param name="optionName"></param>
+        /// <param name="optionValue"></param>
+        void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, byte[] optionValue);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="optionLevel"></param>
+        /// <param name="optionName"></param>
+        /// <param name="optionValue"></param>
+        void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="optionLevel"></param>
+        /// <param name="optionName"></param>
+        /// <param name="optionValue"></param>
+        void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, object optionValue);
+
+        /// <summary>
+        /// See <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="socketShutdown"></param>
+        void Shutdown(SocketShutdown socketShutdown);
+    }
+}

--- a/SocketBase/Sockets/ISocketAsyncEventArgs.cs
+++ b/SocketBase/Sockets/ISocketAsyncEventArgs.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+namespace SuperSocket.SocketBase.Sockets
+{
+    /// <summary>
+    /// SocketAsyncEventArgs interface
+    /// </summary>
+    public interface ISocketAsyncEventArgs : IDisposable
+    {
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        event EventHandler<ISocketAsyncEventArgs> Completed;
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        ISocket AcceptSocket { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        byte[] Buffer { get; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        IList<ArraySegment<byte>> BufferList { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        int BytesTransferred { get; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        Exception ConnectByNameError { get; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        ISocket ConnectSocket { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        bool DisconnectReuseSocket { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        SocketAsyncOperation LastOperation { get; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        int Offset { get; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        IPPacketInformation ReceiveMessageFromPacketInfo { get; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        EndPoint RemoteEndPoint { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        SendPacketsElement[] SendPacketsElements { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        TransmitFileOptions SendPacketsFlags { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        int SendPacketsSendSize { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        SocketError SocketError { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        SocketFlags SocketFlags { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        object UserToken { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        void SetBuffer(byte[] buffer, int offset, int count);
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        void SetBuffer(int offset, int count);
+    }
+}

--- a/SocketBase/Sockets/ISocketEx.cs
+++ b/SocketBase/Sockets/ISocketEx.cs
@@ -1,18 +1,17 @@
-using System;
 using System.Net.Sockets;
 
-namespace SuperSocket.Common
+namespace SuperSocket.SocketBase.Sockets
 {
     /// <summary>
     /// Socket extension class
     /// </summary>
-    public static class SocketEx
+    public static class ISocketEx
     {
         /// <summary>
         /// Close the socket safely.
         /// </summary>
         /// <param name="socket">The socket.</param>
-        public static void SafeClose(this Socket socket)
+        public static void SafeClose(this ISocket socket)
         {
             if (socket == null)
                 return;
@@ -42,7 +41,7 @@ namespace SuperSocket.Common
         /// </summary>
         /// <param name="client">The client.</param>
         /// <param name="data">The data.</param>
-        public static void SendData(this Socket client, byte[] data)
+        public static void SendData(this ISocket client, byte[] data)
         {
             SendData(client, data, 0, data.Length);
         }
@@ -54,7 +53,7 @@ namespace SuperSocket.Common
         /// <param name="data">The data.</param>
         /// <param name="offset">The offset.</param>
         /// <param name="length">The length.</param>
-        public static void SendData(this Socket client, byte[] data, int offset, int length)
+        public static void SendData(this ISocket client, byte[] data, int offset, int length)
         {
             int sent = 0;
             int thisSent = 0;

--- a/SocketBase/Sockets/ISocketFactory.cs
+++ b/SocketBase/Sockets/ISocketFactory.cs
@@ -1,0 +1,24 @@
+﻿using System.Net.Sockets;
+
+namespace SuperSocket.SocketBase.Sockets
+{
+    /// <summary>
+    /// SocketFactory interface
+    /// </summary>
+    public interface ISocketFactory
+    {
+        /// <summary>
+        /// Creates a new <see cref="ISocket"/>
+        /// </summary>
+        /// <param name="addressFamily"></param>
+        /// <param name="socketType"></param>
+        /// <param name="protocolType"></param>
+        ISocket Create(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType);
+
+        /// <summary>
+        /// Creates a new <see cref="ISocketAsyncEventArgs"/>
+        /// </summary>
+        /// <returns></returns>
+        ISocketAsyncEventArgs CreateSocketAsyncEventArgs();
+    }
+}

--- a/SocketBase/Sockets/PassthroughSocket.cs
+++ b/SocketBase/Sockets/PassthroughSocket.cs
@@ -1,0 +1,320 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+namespace SuperSocket.SocketBase.Sockets
+{
+    /// <summary>
+    /// Passthrough Socket
+    /// </summary>
+    public class PassthroughSocket : ISocket
+    {
+        private readonly Socket _socket;
+        
+        /// <inheritdoc />
+        public bool Connected
+        {
+            get
+            {
+                return _socket.Connected;
+            }
+        }
+        
+        /// <inheritdoc />
+        public bool ExclusiveAddressUse
+        {
+            get
+            {
+                return _socket.ExclusiveAddressUse;
+            }
+
+            set
+            {
+                _socket.ExclusiveAddressUse = value;
+            }
+        }
+        
+        /// <inheritdoc />
+        public EndPoint LocalEndPoint
+        {
+            get
+            {
+                return _socket.LocalEndPoint;
+            }
+        }
+
+        /// <inheritdoc />
+        public bool NoDelay
+        {
+            get
+            {
+                return _socket.NoDelay;
+            }
+
+            set
+            {
+                _socket.NoDelay = value;
+            }
+        }
+
+        /// <inheritdoc />
+        public int ReceiveBufferSize
+        {
+            get
+            {
+                return _socket.ReceiveBufferSize;
+            }
+
+            set
+            {
+                _socket.ReceiveBufferSize = value;
+            }
+        }
+
+        /// <inheritdoc />
+        public EndPoint RemoteEndPoint
+        {
+            get
+            {
+                return _socket.RemoteEndPoint;
+            }
+        }
+
+        /// <inheritdoc />
+        public int SendBufferSize
+        {
+            get
+            {
+                return _socket.SendBufferSize;
+            }
+
+            set
+            {
+                _socket.SendBufferSize = value;
+            }
+        }
+
+        /// <inheritdoc />
+        public int SendTimeout
+        {
+            get
+            {
+                return _socket.SendTimeout;
+            }
+
+            set
+            {
+                _socket.SendTimeout = value;
+            }
+        }
+
+        /// <summary>
+        /// Instantiates a <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="socket"></param>
+        public PassthroughSocket(Socket socket)
+        {
+            _socket = socket;
+        }
+
+        /// <summary>
+        /// Instantiates a <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="socketInformation"></param>
+        public PassthroughSocket(SocketInformation socketInformation)
+        {
+            _socket = new Socket(socketInformation);
+        }
+
+        /// <summary>
+        /// Instantiates a <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="addressFamily"></param>
+        /// <param name="socketType"></param>
+        /// <param name="protocolType"></param>
+        public PassthroughSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+        {
+            _socket = new Socket(addressFamily, socketType, protocolType);
+        }
+
+        /// <summary>
+        /// Instantiates a <see cref="System.Net.Sockets.Socket"/>
+        /// </summary>
+        /// <param name="socketType"></param>
+        /// <param name="protocolType"></param>
+        public PassthroughSocket(SocketType socketType, ProtocolType protocolType)
+        {
+            _socket = new Socket(socketType, protocolType);
+        }
+
+        /// <inheritdoc />
+        public bool AcceptAsync(ISocketAsyncEventArgs e)
+        {
+            return _socket.AcceptAsync(((PassthroughSocketAsyncEventArgs)e).SocketAsyncEventArgs);
+        }
+
+        /// <inheritdoc />
+        public IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback callback, object state)
+        {
+            return _socket.BeginConnect(remoteEP, callback, state);
+        }
+
+        /// <inheritdoc />
+        public void Bind(EndPoint localEP)
+        {
+            _socket.Bind(localEP);
+        }
+
+        /// <inheritdoc />
+        public void Close()
+        {
+            _socket.Close();
+        }
+
+        /// <inheritdoc />
+        public void Close(int timeout)
+        {
+            _socket.Close(timeout);
+        }
+
+        /// <inheritdoc />
+        public Stream CreateStream()
+        {
+            return new NetworkStream(_socket);
+        }
+
+        /// <inheritdoc />
+        public void EndConnect(IAsyncResult asyncResult)
+        {
+            _socket.EndConnect(asyncResult);
+        }
+
+        /// <inheritdoc />
+        public int IOControl(int ioControlCode, byte[] optionInValue, byte[] optionOutValue)
+        {
+            return _socket.IOControl(ioControlCode, optionInValue, optionOutValue);
+        }
+
+        /// <inheritdoc />
+        public int IOControl(IOControlCode ioControlCode, byte[] optionInValue, byte[] optionOutValue)
+        {
+            return _socket.IOControl(ioControlCode, optionInValue, optionOutValue);
+        }
+
+        /// <inheritdoc />
+        public void Listen(int backlog)
+        {
+            _socket.Listen(backlog);
+        }
+
+        /// <inheritdoc />
+        public bool ReceiveAsync(ISocketAsyncEventArgs e)
+        {
+            return _socket.ReceiveAsync(((PassthroughSocketAsyncEventArgs)e).SocketAsyncEventArgs);
+        }
+
+        /// <inheritdoc />
+        public bool ReceiveFromAsync(ISocketAsyncEventArgs e)
+        {
+            return _socket.ReceiveFromAsync(((PassthroughSocketAsyncEventArgs)e).SocketAsyncEventArgs);
+        }
+
+        /// <inheritdoc />
+        public int Send(byte[] buffer)
+        {
+            return _socket.Send(buffer);
+        }
+
+        /// <inheritdoc />
+        public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        {
+            return _socket.Send(buffer, offset, size, socketFlags);
+        }
+
+        /// <inheritdoc />
+        public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode)
+        {
+            return _socket.Send(buffer, offset, size, socketFlags, out errorCode);
+        }
+
+        /// <inheritdoc />
+        public int Send(byte[] buffer, int size, SocketFlags socketFlags)
+        {
+            return _socket.Send(buffer, size, socketFlags);
+        }
+
+        /// <inheritdoc />
+        public int Send(byte[] buffer, SocketFlags socketFlags)
+        {
+            return _socket.Send(buffer, socketFlags);
+        }
+
+        /// <inheritdoc />
+        public int Send(IList<ArraySegment<byte>> buffers)
+        {
+            return _socket.Send(buffers);
+        }
+
+        /// <inheritdoc />
+        public int Send(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags)
+        {
+            return _socket.Send(buffers, socketFlags);
+        }
+
+        /// <inheritdoc />
+        public int Send(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out SocketError socketError)
+        {
+            return _socket.Send(buffers, socketFlags, out socketError);
+        }
+
+        /// <inheritdoc />
+        public bool SendAsync(ISocketAsyncEventArgs e)
+        {
+            return _socket.SendAsync(((PassthroughSocketAsyncEventArgs)e).SocketAsyncEventArgs);
+        }
+
+        /// <inheritdoc />
+        public int SendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP)
+        {
+            return _socket.SendTo(buffer, offset, size, socketFlags, remoteEP);
+        }
+
+        /// <inheritdoc />
+        public bool SendToAsync(ISocketAsyncEventArgs e)
+        {
+            return _socket.SendToAsync(((PassthroughSocketAsyncEventArgs)e).SocketAsyncEventArgs);
+        }
+
+        /// <inheritdoc />
+        public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, bool optionValue)
+        {
+            _socket.SetSocketOption(optionLevel, optionName, optionValue);
+        }
+
+        /// <inheritdoc />
+        public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, byte[] optionValue)
+        {
+            _socket.SetSocketOption(optionLevel, optionName, optionValue);
+        }
+
+        /// <inheritdoc />
+        public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue)
+        {
+            _socket.SetSocketOption(optionLevel, optionName, optionValue);
+        }
+
+        /// <inheritdoc />
+        public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, object optionValue)
+        {
+            _socket.SetSocketOption(optionLevel, optionName, optionValue);
+        }
+
+        /// <inheritdoc />
+        public void Shutdown(SocketShutdown socketShutdown)
+        {
+            _socket.Shutdown(socketShutdown);
+        }
+    }
+}

--- a/SocketBase/Sockets/PassthroughSocketAsyncEventArgs.cs
+++ b/SocketBase/Sockets/PassthroughSocketAsyncEventArgs.cs
@@ -1,0 +1,321 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+namespace SuperSocket.SocketBase.Sockets
+{
+    /// <summary>
+    /// Passthrough SocketAsyncEventArgs
+    /// </summary>
+    public class PassthroughSocketAsyncEventArgs : ISocketAsyncEventArgs
+    {
+        private readonly SocketAsyncEventArgs _socketAsyncEventArgs;
+
+        /// <summary>
+        /// SocketAsyncEventArgs
+        /// </summary>
+        public SocketAsyncEventArgs SocketAsyncEventArgs
+        {
+            get
+            {
+                return _socketAsyncEventArgs;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public event EventHandler<ISocketAsyncEventArgs> Completed;
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public ISocket AcceptSocket { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public byte[] Buffer {
+            get
+            {
+                return _socketAsyncEventArgs.Buffer;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public IList<ArraySegment<byte>> BufferList
+        {
+            get
+            {
+                return _socketAsyncEventArgs.BufferList;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.BufferList = value;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public int BytesTransferred
+        {
+            get
+            {
+                return _socketAsyncEventArgs.BytesTransferred;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public Exception ConnectByNameError
+        {
+            get
+            {
+                return _socketAsyncEventArgs.ConnectByNameError;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public ISocket ConnectSocket { get; set; }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                return _socketAsyncEventArgs.Count;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public bool DisconnectReuseSocket
+        {
+            get
+            {
+                return _socketAsyncEventArgs.DisconnectReuseSocket;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.DisconnectReuseSocket = value;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public SocketAsyncOperation LastOperation
+        {
+            get
+            {
+                return _socketAsyncEventArgs.LastOperation;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public int Offset
+        {
+            get
+            {
+                return _socketAsyncEventArgs.Offset;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public IPPacketInformation ReceiveMessageFromPacketInfo
+        {
+            get
+            {
+                return _socketAsyncEventArgs.ReceiveMessageFromPacketInfo;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public EndPoint RemoteEndPoint
+        {
+            get
+            {
+                return _socketAsyncEventArgs.RemoteEndPoint;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.RemoteEndPoint = value;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public SendPacketsElement[] SendPacketsElements
+        {
+            get
+            {
+                return _socketAsyncEventArgs.SendPacketsElements;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.SendPacketsElements = value;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public TransmitFileOptions SendPacketsFlags
+        {
+            get
+            {
+                return _socketAsyncEventArgs.SendPacketsFlags;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.SendPacketsFlags = value;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public int SendPacketsSendSize
+        {
+            get
+            {
+                return _socketAsyncEventArgs.SendPacketsSendSize;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.SendPacketsSendSize = value;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public SocketError SocketError
+        {
+            get
+            {
+                return _socketAsyncEventArgs.SocketError;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.SocketError = value;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public SocketFlags SocketFlags
+        {
+            get
+            {
+                return _socketAsyncEventArgs.SocketFlags;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.SocketFlags = value;
+            }
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        public object UserToken
+        {
+            get
+            {
+                return _socketAsyncEventArgs.UserToken;
+            }
+
+            set
+            {
+                _socketAsyncEventArgs.UserToken = value;
+            }
+        }
+
+        /// <summary>
+        /// Instantiates a <see cref="SocketAsyncEventArgs"/> adapter
+        /// </summary>
+        public PassthroughSocketAsyncEventArgs()
+        {
+            _socketAsyncEventArgs = new SocketAsyncEventArgs();
+            _socketAsyncEventArgs.Completed += (sender, args) =>
+            {
+                this.Map(args);
+
+                this.OnPassthroughSocketAsyncEventArgsCompleted();
+            };
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        /// <param name="buffer"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        public void SetBuffer(byte[] buffer, int offset, int count)
+        {
+            _socketAsyncEventArgs.SetBuffer(buffer, offset, count);
+        }
+
+        /// <summary>
+        /// See <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        public void SetBuffer(int offset, int count)
+        {
+            _socketAsyncEventArgs.SetBuffer(offset, count);
+        }
+
+        /// <summary>
+        /// Maps a <see cref="SocketAsyncEventArgs"/>
+        /// </summary>
+        /// <param name="e"></param>
+        public void Map(SocketAsyncEventArgs e)
+        {
+            this.AcceptSocket = new PassthroughSocket(e.AcceptSocket);
+            this.ConnectSocket = new PassthroughSocket(e.ConnectSocket);
+        }
+
+        /// <summary>
+        /// Fires Completed event
+        /// </summary>
+        public void OnPassthroughSocketAsyncEventArgsCompleted()
+        {
+            var handler = Completed;
+            if (null != handler)
+            {
+                handler(this, this);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose() { }
+    }
+}

--- a/SocketBase/Sockets/PassthroughSocketFactory.cs
+++ b/SocketBase/Sockets/PassthroughSocketFactory.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Sockets;
+
+namespace SuperSocket.SocketBase.Sockets
+{
+    /// <summary>
+    /// Passthrough Socket Factory
+    /// </summary>
+    public class PassthroughSocketFactory : ISocketFactory
+    {
+        /// <inheritdoc />
+        public ISocket Create(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+        {
+            return new PassthroughSocket(addressFamily, socketType, protocolType);
+        }
+
+        /// <inheritdoc />
+        public ISocketAsyncEventArgs CreateSocketAsyncEventArgs()
+        {
+            return new PassthroughSocketAsyncEventArgs();
+        }
+    }
+}

--- a/SocketBase/SuperSocket.SocketBase.Net45.csproj
+++ b/SocketBase/SuperSocket.SocketBase.Net45.csproj
@@ -100,6 +100,9 @@
     <Compile Include="IActiveConnector.cs" />
     <Compile Include="IBootstrap.cs" />
     <Compile Include="ILoggerProvider.cs" />
+    <Compile Include="Sockets\ISocket.cs" />
+    <Compile Include="Sockets\ISocketAsyncEventArgs.cs" />
+    <Compile Include="Sockets\ISocketFactory.cs" />
     <Compile Include="IsolationMode.cs" />
     <Compile Include="IStatusInfoSource.cs" />
     <Compile Include="ISystemEndPoint.cs" />
@@ -164,11 +167,15 @@
     <Compile Include="Security\CertificateManager.cs" />
     <Compile Include="ServerState.cs" />
     <Compile Include="SessionHandler.cs" />
+    <Compile Include="Sockets\PassthroughSocket.cs" />
+    <Compile Include="Sockets\ISocketEx.cs" />
+    <Compile Include="Sockets\PassthroughSocketFactory.cs" />
     <Compile Include="SocketMode.cs" />
     <Compile Include="AppServer.cs" />
     <Compile Include="AppServerBase.cs" />
     <Compile Include="AppSession.cs" />
     <Compile Include="Command\StringCommandBase.cs" />
+    <Compile Include="Sockets\PassthroughSocketAsyncEventArgs.cs" />
     <Compile Include="StatusInfoCollection.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SocketEngine/AsyncSocket/SocketAsyncEventArgsProxy.cs
+++ b/SocketEngine/AsyncSocket/SocketAsyncEventArgsProxy.cs
@@ -5,12 +5,13 @@ using System.Net.Sockets;
 using System.Text;
 using SuperSocket.Common;
 using SuperSocket.SocketBase;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketEngine.AsyncSocket
 {
     class SocketAsyncEventArgsProxy
     {
-        public SocketAsyncEventArgs SocketEventArgs { get; private set; }
+        public ISocketAsyncEventArgs SocketEventArgs { get; private set; }
 
         public int OrigOffset { get; private set; }
 
@@ -21,21 +22,21 @@ namespace SuperSocket.SocketEngine.AsyncSocket
 
         }
 
-        public SocketAsyncEventArgsProxy(SocketAsyncEventArgs socketEventArgs)
+        public SocketAsyncEventArgsProxy(ISocketAsyncEventArgs socketEventArgs)
             : this(socketEventArgs, true)
         {
             
         }
 
-        public SocketAsyncEventArgsProxy(SocketAsyncEventArgs socketEventArgs, bool isRecyclable)
+        public SocketAsyncEventArgsProxy(ISocketAsyncEventArgs socketEventArgs, bool isRecyclable)
         {
             SocketEventArgs = socketEventArgs;
             OrigOffset = socketEventArgs.Offset;
-            SocketEventArgs.Completed += new EventHandler<SocketAsyncEventArgs>(SocketEventArgs_Completed);
+            SocketEventArgs.Completed += new EventHandler<ISocketAsyncEventArgs>(SocketEventArgs_Completed);
             IsRecyclable = isRecyclable;
         }
 
-        static void SocketEventArgs_Completed(object sender, SocketAsyncEventArgs e)
+        static void SocketEventArgs_Completed(object sender, ISocketAsyncEventArgs e)
         {
             var socketSession = e.UserToken as IAsyncSocketSession;
 

--- a/SocketEngine/AsyncStreamSocketSession.cs
+++ b/SocketEngine/AsyncStreamSocketSession.cs
@@ -14,6 +14,7 @@ using SuperSocket.SocketBase.Command;
 using SuperSocket.SocketBase.Config;
 using SuperSocket.SocketBase.Logging;
 using SuperSocket.SocketBase.Protocol;
+using SuperSocket.SocketBase.Sockets;
 using SuperSocket.SocketEngine.AsyncSocket;
 
 namespace SuperSocket.SocketEngine
@@ -59,13 +60,13 @@ namespace SuperSocket.SocketEngine
 
         private bool m_IsReset;
 
-        public AsyncStreamSocketSession(Socket client, SslProtocols security, SocketAsyncEventArgsProxy socketAsyncProxy)
+        public AsyncStreamSocketSession(ISocket client, SslProtocols security, SocketAsyncEventArgsProxy socketAsyncProxy)
             : this(client, security, socketAsyncProxy, false)
         {
 
         }
 
-        public AsyncStreamSocketSession(Socket client, SslProtocols security, SocketAsyncEventArgsProxy socketAsyncProxy, bool isReset)
+        public AsyncStreamSocketSession(ISocket client, SslProtocols security, SocketAsyncEventArgsProxy socketAsyncProxy, bool isReset)
             : base(client)
         {
             SecureProtocol = security;
@@ -171,10 +172,10 @@ namespace SuperSocket.SocketEngine
         {
             //Enable client certificate function only if ClientCertificateRequired is true in the configuration
             if(!certConfig.ClientCertificateRequired)
-                return new SslStream(new NetworkStream(Client), false);
+                return new SslStream(Client.CreateStream(), false); //ToDo:
 
             //Subscribe the client validation callback
-            return new SslStream(new NetworkStream(Client), false, ValidateClientCertificate);
+            return new SslStream(Client.CreateStream(), false, ValidateClientCertificate);
         }
 
         private bool ValidateClientCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
@@ -201,7 +202,7 @@ namespace SuperSocket.SocketEngine
             switch (secureProtocol)
             {
                 case (SslProtocols.None):
-                    m_Stream = new NetworkStream(Client);
+                    m_Stream = Client.CreateStream();
                     break;
                 case (SslProtocols.Default):
                 case (SslProtocols.Tls):

--- a/SocketEngine/IAsyncSocketSession.cs
+++ b/SocketEngine/IAsyncSocketSession.cs
@@ -6,6 +6,7 @@ using System.Text;
 using SuperSocket.Common;
 using SuperSocket.SocketBase;
 using SuperSocket.SocketBase.Logging;
+using SuperSocket.SocketBase.Sockets;
 using SuperSocket.SocketEngine.AsyncSocket;
 
 namespace SuperSocket.SocketEngine
@@ -14,11 +15,11 @@ namespace SuperSocket.SocketEngine
     {
         SocketAsyncEventArgsProxy SocketAsyncProxy { get; }
         
-        Socket Client { get; }
+        ISocket Client { get; }
     }
 
     interface IAsyncSocketSession : IAsyncSocketSessionBase
     {
-        void ProcessReceive(SocketAsyncEventArgs e);
+        void ProcessReceive(ISocketAsyncEventArgs e);
     }
 }

--- a/SocketEngine/ISocketListener.cs
+++ b/SocketEngine/ISocketListener.cs
@@ -6,12 +6,13 @@ using SuperSocket.SocketBase;
 using SuperSocket.SocketBase.Config;
 using System.Net.Sockets;
 using System.Net;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketEngine
 {
     delegate void ErrorHandler(ISocketListener listener, Exception e);
 
-    delegate void NewClientAcceptHandler(ISocketListener listener, Socket client, object state);
+    delegate void NewClientAcceptHandler(ISocketListener listener, ISocket client, object state);
 
     /// <summary>
     /// The interface for socket listener

--- a/SocketEngine/SocketListenerBase.cs
+++ b/SocketEngine/SocketListenerBase.cs
@@ -6,21 +6,24 @@ using System.Net.Sockets;
 using System.Text;
 using SuperSocket.SocketBase;
 using SuperSocket.SocketBase.Config;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketEngine
 {
     abstract class SocketListenerBase : ISocketListener
     {
         public ListenerInfo Info { get; private set; }
+        public ISocketFactory SocketFactory { get; private set; }
 
         public IPEndPoint EndPoint
         {
             get { return Info.EndPoint; }
         }
 
-        protected SocketListenerBase(ListenerInfo info)
+        protected SocketListenerBase(ListenerInfo info, ISocketFactory socketFactory)
         {
             Info = info;
+            SocketFactory = socketFactory ?? new PassthroughSocketFactory();
         }
 
         /// <summary>
@@ -49,7 +52,7 @@ namespace SuperSocket.SocketEngine
             OnError(new Exception(errorMessage));
         }
 
-        protected virtual void OnNewClientAccepted(Socket socket, object state)
+        protected virtual void OnNewClientAccepted(ISocket socket, object state)
         {
             var handler = NewClientAccepted;
 
@@ -57,7 +60,7 @@ namespace SuperSocket.SocketEngine
                 handler(this, socket, state);
         }
 
-        protected void OnNewClientAcceptedAsync(Socket socket, object state)
+        protected void OnNewClientAcceptedAsync(ISocket socket, object state)
         {
             var handler = NewClientAccepted;
 

--- a/SocketEngine/SocketServerBase.cs
+++ b/SocketEngine/SocketServerBase.cs
@@ -14,6 +14,7 @@ using SuperSocket.SocketBase;
 using SuperSocket.SocketBase.Command;
 using SuperSocket.SocketBase.Logging;
 using SuperSocket.SocketBase.Protocol;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketEngine
 {
@@ -106,7 +107,7 @@ namespace SuperSocket.SocketEngine
             return true;
         }
 
-        protected abstract void OnNewClientAccepted(ISocketListener listener, Socket client, object state);
+        protected abstract void OnNewClientAccepted(ISocketListener listener, ISocket client, object state);
 
         void OnListenerError(ISocketListener listener, Exception e)
         {

--- a/SocketEngine/TcpAsyncSocketListener.cs
+++ b/SocketEngine/TcpAsyncSocketListener.cs
@@ -7,6 +7,7 @@ using System.Text;
 using SuperSocket.SocketBase;
 using SuperSocket.SocketBase.Config;
 using SuperSocket.SocketBase.Logging;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketEngine
 {
@@ -17,12 +18,12 @@ namespace SuperSocket.SocketEngine
     {
         private int m_ListenBackLog;
 
-        private Socket m_ListenSocket;
+        private ISocket m_ListenSocket;
 
-        private SocketAsyncEventArgs m_AcceptSAE;
+        private ISocketAsyncEventArgs m_AcceptSAE;
 
-        public TcpAsyncSocketListener(ListenerInfo info)
-            : base(info)
+        public TcpAsyncSocketListener(ListenerInfo info, ISocketFactory socketFactory)
+            : base(info, socketFactory)
         {
             m_ListenBackLog = info.BackLog;
         }
@@ -34,7 +35,7 @@ namespace SuperSocket.SocketEngine
         /// <returns></returns>
         public override bool Start(IServerConfig config)
         {
-            m_ListenSocket = new Socket(this.Info.EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            m_ListenSocket = this.SocketFactory.Create(this.Info.EndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
             try
             {
@@ -44,12 +45,22 @@ namespace SuperSocket.SocketEngine
                 m_ListenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 m_ListenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontLinger, true);
 
+
+                var acceptEventArg = this.SocketFactory.CreateSocketAsyncEventArgs();
+                m_AcceptSAE = acceptEventArg;
+                acceptEventArg.Completed += new EventHandler<ISocketAsyncEventArgs>(acceptEventArg_Completed);
+
+                if (!m_ListenSocket.AcceptAsync(acceptEventArg))
+                    ProcessAccept(acceptEventArg);
+
+                /*
                 SocketAsyncEventArgs acceptEventArg = new SocketAsyncEventArgs();
                 m_AcceptSAE = acceptEventArg;
                 acceptEventArg.Completed += new EventHandler<SocketAsyncEventArgs>(acceptEventArg_Completed);
 
-                if (!m_ListenSocket.AcceptAsync(acceptEventArg))
+                if (!m_ListenSocket.AcceptAsync(x))
                     ProcessAccept(acceptEventArg);
+                */
 
                 return true;
 
@@ -62,14 +73,14 @@ namespace SuperSocket.SocketEngine
         }
 
 
-        void acceptEventArg_Completed(object sender, SocketAsyncEventArgs e)
+        void acceptEventArg_Completed(object sender, ISocketAsyncEventArgs e)
         {
             ProcessAccept(e);
         }
 
-        void ProcessAccept(SocketAsyncEventArgs e)
+        void ProcessAccept(ISocketAsyncEventArgs e)
         {
-            Socket socket = null;
+            ISocket socket = null;
 
             if (e.SocketError != SocketError.Success)
             {
@@ -132,7 +143,7 @@ namespace SuperSocket.SocketEngine
                 if (m_ListenSocket == null)
                     return;
 
-                m_AcceptSAE.Completed -= new EventHandler<SocketAsyncEventArgs>(acceptEventArg_Completed);
+                m_AcceptSAE.Completed -= new EventHandler<ISocketAsyncEventArgs>(acceptEventArg_Completed);
                 m_AcceptSAE.Dispose();
                 m_AcceptSAE = null;
 

--- a/SocketEngine/TcpSocketServerBase.cs
+++ b/SocketEngine/TcpSocketServerBase.cs
@@ -10,6 +10,7 @@ using SuperSocket.SocketBase;
 using SuperSocket.SocketBase.Command;
 using SuperSocket.SocketBase.Logging;
 using SuperSocket.SocketBase.Protocol;
+using SuperSocket.SocketBase.Sockets;
 
 namespace SuperSocket.SocketEngine
 {
@@ -41,7 +42,7 @@ namespace SuperSocket.SocketEngine
             m_SendBufferSize = config.SendBufferSize;
         }
 
-        protected IAppSession CreateSession(Socket client, ISocketSession session)
+        protected IAppSession CreateSession(ISocket client, ISocketSession session)
         {
             if (m_SendTimeOut > 0)
                 client.SendTimeout = m_SendTimeOut;
@@ -65,7 +66,7 @@ namespace SuperSocket.SocketEngine
 
         protected override ISocketListener CreateListener(ListenerInfo listenerInfo)
         {
-            return new TcpAsyncSocketListener(listenerInfo);
+            return new TcpAsyncSocketListener(listenerInfo, this.AppServer.SocketFactory);
         }
     }
 }


### PR DESCRIPTION
Not instantiating Sockets directly, allows to inject an ISocketFactory
in order to be able to mock the socket and run tests in-memory.