### PR TITLE
Initialize ReflectCommandLoader.

### DIFF
--- a/SocketBase/AppServerBase.cs
+++ b/SocketBase/AppServerBase.cs
@@ -774,7 +774,9 @@ namespace SuperSocket.SocketBase
         /// <returns></returns>
         protected virtual bool SetupCommandLoaders(List<ICommandLoader<ICommand<TAppSession, TRequestInfo>>> commandLoaders)
         {
-            commandLoaders.Add(new ReflectCommandLoader<ICommand<TAppSession, TRequestInfo>>());
+	    var reflectionLoader = new ReflectCommandLoader<ICommand<TAppSession, TRequestInfo>>();
+ 	    reflectionLoader.Initialize(RootConfig, this);
+            commandLoaders.Add(reflectionLoader);
             return true;
         }
 


### PR DESCRIPTION
ReflectCommandLoader is added to the list of command loaders by default.  However, it is never initialized and so it always results in a NullReferenceException as it doesn't have a reference to the app server when TryLoadCommands is called on it.