### PR TITLE
fix problems reported by resharper

### DIFF
--- a/src/SuperSocket.Channel/ChannelBase.cs
+++ b/src/SuperSocket.Channel/ChannelBase.cs
@@ -13,8 +13,8 @@ namespace SuperSocket.Channel
 
         public event Action<IChannel, TPackageInfo> PackageReceived
         {
-            add { _packageReceived += value; }
-            remove { _packageReceived -= value; }
+            add => _packageReceived += value;
+            remove => _packageReceived -= value;
         }
 
         protected void OnPackageReceived(TPackageInfo package)
@@ -26,8 +26,8 @@ namespace SuperSocket.Channel
 
         public event EventHandler Closed
         {
-            add { _closed += value; }
-            remove { _closed -= value; }
+            add => _closed += value;
+            remove => _closed -= value;
         }
 
         protected virtual void OnClosed()

--- a/src/SuperSocket.Channel/PipeChannel.cs
+++ b/src/SuperSocket.Channel/PipeChannel.cs
@@ -11,8 +11,8 @@ namespace SuperSocket.Channel
         where TPackageInfo : class
     {
         private IPipelineFilter<TPackageInfo> _pipelineFilter;
-        
-        public PipeChannel(IPipelineFilter<TPackageInfo> pipelineFilter)
+
+        protected PipeChannel(IPipelineFilter<TPackageInfo> pipelineFilter)
         {
             _pipelineFilter = pipelineFilter;
         }
@@ -67,7 +67,7 @@ namespace SuperSocket.Channel
             var packageInfo = currentPipelineFilter.Filter(ref seqReader);
 
             if (currentPipelineFilter.NextFilter != null)
-                _pipelineFilter = currentPipelineFilter = currentPipelineFilter.NextFilter;
+                _pipelineFilter = currentPipelineFilter.NextFilter;
         
             // continue receive...
             if (packageInfo == null)

--- a/src/SuperSocket.Channel/PipeChannel.cs
+++ b/src/SuperSocket.Channel/PipeChannel.cs
@@ -2,7 +2,6 @@
 using System.Buffers;
 using System.Threading.Tasks;
 using System.IO.Pipelines;
-using System.Net.Sockets;
 using SuperSocket.ProtoBase;
 using System.Runtime.InteropServices;
 

--- a/src/SuperSocket.Channel/TcpPipeChannel.cs
+++ b/src/SuperSocket.Channel/TcpPipeChannel.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Buffers;
 using System.Threading.Tasks;
 using System.IO.Pipelines;
 using System.Net.Sockets;
 using SuperSocket.ProtoBase;
-using System.Runtime.InteropServices;
 
 namespace SuperSocket.Channel
 {

--- a/src/SuperSocket.Primitives/IAppSession.cs
+++ b/src/SuperSocket.Primitives/IAppSession.cs
@@ -1,5 +1,3 @@
-using System.Threading.Tasks;
-
 namespace SuperSocket
 {
     public interface IAppSession

--- a/src/SuperSocket.Primitives/IChannel.cs
+++ b/src/SuperSocket.Primitives/IChannel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using SuperSocket;
 
 namespace SuperSocket
 {

--- a/src/SuperSocket.Primitives/IChannel.cs
+++ b/src/SuperSocket.Primitives/IChannel.cs
@@ -12,7 +12,7 @@ namespace SuperSocket
         event EventHandler Closed;
     }
 
-    public interface IChannel<TPackageInfo> : IChannel
+    public interface IChannel<out TPackageInfo> : IChannel
         where TPackageInfo : class
     {
         event Action<IChannel, TPackageInfo> PackageReceived;

--- a/src/SuperSocket.Primitives/IListener.cs
+++ b/src/SuperSocket.Primitives/IListener.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 
 namespace SuperSocket

--- a/src/SuperSocket.Primitives/IListenerFactory.cs
+++ b/src/SuperSocket.Primitives/IListenerFactory.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-
 namespace SuperSocket
 {
     public interface IListenerFactory

--- a/src/SuperSocket.ProtoBase/DefaultPipelineFilterFactory.cs
+++ b/src/SuperSocket.ProtoBase/DefaultPipelineFilterFactory.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Buffers;
-
 namespace SuperSocket.ProtoBase
 {
     public class DefaultPipelineFilterFactory<TPackageInfo, TPipelineFilter> : IPipelineFilterFactory<TPackageInfo>

--- a/src/SuperSocket.ProtoBase/DelegatePipelineFilterFactory.cs
+++ b/src/SuperSocket.ProtoBase/DelegatePipelineFilterFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 
 namespace SuperSocket.ProtoBase
 {

--- a/src/SuperSocket.ProtoBase/DelegatePipelineFilterFactory.cs
+++ b/src/SuperSocket.ProtoBase/DelegatePipelineFilterFactory.cs
@@ -5,7 +5,7 @@ namespace SuperSocket.ProtoBase
     public class DelegatePipelineFilterFactory<TPackageInfo> : IPipelineFilterFactory<TPackageInfo>
         where TPackageInfo : class
     {
-        private Func<object, IPipelineFilter<TPackageInfo>> _factory;
+        private readonly Func<object, IPipelineFilter<TPackageInfo>> _factory;
 
         public DelegatePipelineFilterFactory(Func<object, IPipelineFilter<TPackageInfo>> factory)
         {

--- a/src/SuperSocket.ProtoBase/Extensions.cs
+++ b/src/SuperSocket.ProtoBase/Extensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Buffers;
 using System.Text;
 

--- a/src/SuperSocket.ProtoBase/FixedHeaderPipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/FixedHeaderPipelineFilter.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Buffers;
-using System.Collections;
-using System.Threading.Tasks;
 
 namespace SuperSocket.ProtoBase
 {

--- a/src/SuperSocket.ProtoBase/FixedHeaderPipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/FixedHeaderPipelineFilter.cs
@@ -5,10 +5,10 @@ namespace SuperSocket.ProtoBase
     public abstract class FixedHeaderPipelineFilter<TPackageInfo> : FixedSizePipelineFilter<TPackageInfo>
         where TPackageInfo : class
     {
-        private bool _foundHeader = false;
-        private int _headerSize;
+        private bool _foundHeader;
+        private readonly int _headerSize;
 
-        public FixedHeaderPipelineFilter(int headerSize)
+        protected FixedHeaderPipelineFilter(int headerSize)
             : base(headerSize)
         {
             _headerSize = headerSize;

--- a/src/SuperSocket.ProtoBase/FixedSizePipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/FixedSizePipelineFilter.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Buffers;
-using System.Collections;
-using System.Threading.Tasks;
 
 namespace SuperSocket.ProtoBase
 {

--- a/src/SuperSocket.ProtoBase/FixedSizePipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/FixedSizePipelineFilter.cs
@@ -7,7 +7,7 @@ namespace SuperSocket.ProtoBase
     {
         private int _size;
 
-        public FixedSizePipelineFilter(int size)
+        protected FixedSizePipelineFilter(int size)
         {
             _size = size;
         }

--- a/src/SuperSocket.ProtoBase/IPackageDecoder.cs
+++ b/src/SuperSocket.ProtoBase/IPackageDecoder.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Buffers;
 
 namespace SuperSocket.ProtoBase

--- a/src/SuperSocket.ProtoBase/IPackageDecoder.cs
+++ b/src/SuperSocket.ProtoBase/IPackageDecoder.cs
@@ -2,7 +2,7 @@ using System.Buffers;
 
 namespace SuperSocket.ProtoBase
 {
-    public interface IPackageDecoder<TPackageInfo>
+    public interface IPackageDecoder<out TPackageInfo>
         where TPackageInfo : class
     {
         TPackageInfo Decode(ReadOnlySequence<byte> buffer);

--- a/src/SuperSocket.ProtoBase/IPipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/IPipelineFilter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Buffers;
 
 namespace SuperSocket.ProtoBase

--- a/src/SuperSocket.ProtoBase/IPipelineFilterFactory.cs
+++ b/src/SuperSocket.ProtoBase/IPipelineFilterFactory.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Buffers;
-
 namespace SuperSocket.ProtoBase
 {
     public interface IPipelineFilterFactory<TPackageInfo>

--- a/src/SuperSocket.ProtoBase/LinePipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/LinePipelineFilter.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Buffers;
-using System.Text;
-
 namespace SuperSocket.ProtoBase
 {
     public class LinePipelineFilter : TerminatorTextPipelineFilter

--- a/src/SuperSocket.ProtoBase/LinePipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/LinePipelineFilter.cs
@@ -4,7 +4,7 @@ namespace SuperSocket.ProtoBase
     {
 
         public LinePipelineFilter()
-            : base(new byte[] { (byte)'\r', (byte)'\n' })
+            : base(new[] { (byte)'\r', (byte)'\n' })
         {
 
         }

--- a/src/SuperSocket.ProtoBase/PipelineFilterBase.cs
+++ b/src/SuperSocket.ProtoBase/PipelineFilterBase.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Buffers;
 
 namespace SuperSocket.ProtoBase

--- a/src/SuperSocket.ProtoBase/TerminatorPipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/TerminatorPipelineFilter.cs
@@ -8,7 +8,7 @@ namespace SuperSocket.ProtoBase
     {
         private readonly ReadOnlyMemory<byte> _terminator;
 
-        public TerminatorPipelineFilter(ReadOnlyMemory<byte> terminator)
+        protected TerminatorPipelineFilter(ReadOnlyMemory<byte> terminator)
         {
             _terminator = terminator;
         }

--- a/src/SuperSocket.ProtoBase/TerminatorPipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/TerminatorPipelineFilter.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Buffers;
-using System.Collections;
-using System.Threading.Tasks;
 
 namespace SuperSocket.ProtoBase
 {

--- a/src/SuperSocket.ProtoBase/TerminatorPipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/TerminatorPipelineFilter.cs
@@ -6,7 +6,7 @@ namespace SuperSocket.ProtoBase
     public abstract class TerminatorPipelineFilter<TPackageInfo> : PipelineFilterBase<TPackageInfo>
         where TPackageInfo : class
     {
-        private ReadOnlyMemory<byte> _terminator;
+        private readonly ReadOnlyMemory<byte> _terminator;
 
         public TerminatorPipelineFilter(ReadOnlyMemory<byte> terminator)
         {

--- a/src/SuperSocket.ProtoBase/TextPackageInfo.cs
+++ b/src/SuperSocket.ProtoBase/TextPackageInfo.cs
@@ -1,6 +1,3 @@
-using System;
-
-
 namespace SuperSocket.ProtoBase
 {
     public class TextPackageInfo

--- a/src/SuperSocket.Server/AppSession.cs
+++ b/src/SuperSocket.Server/AppSession.cs
@@ -11,10 +11,10 @@ namespace SuperSocket.Server
             SessionID = Guid.NewGuid().ToString();
         }
 
-        public string SessionID { get; private set; }
+        public string SessionID { get; }
 
-        public IServerInfo Server { get; private set; }
+        public IServerInfo Server { get; }
 
-        public IChannel Channel { get; private set; }
+        public IChannel Channel { get; }
     }
 }

--- a/src/SuperSocket.Server/AppSession.cs
+++ b/src/SuperSocket.Server/AppSession.cs
@@ -1,11 +1,4 @@
 using System;
-using System.IO.Pipelines;
-using System.Net.Sockets;
-using System.Threading.Tasks;
-using System.Buffers;
-using SuperSocket;
-using SuperSocket.Channel;
-using SuperSocket.ProtoBase;
 
 namespace SuperSocket.Server
 {

--- a/src/SuperSocket.Server/SuperSocketServer.cs
+++ b/src/SuperSocket.Server/SuperSocketServer.cs
@@ -29,7 +29,7 @@ namespace SuperSocket.Server
 
         private ILogger _logger;
 
-        private bool _configured = false;
+        private bool _configured;
 
         private int _sessionCount;
 

--- a/src/SuperSocket.Server/SuperSocketServer.cs
+++ b/src/SuperSocket.Server/SuperSocketServer.cs
@@ -23,10 +23,7 @@ namespace SuperSocket.Server
         /// Server's name
         /// </summary>
         /// <returns>the name of the server instance</returns>
-        public string Name 
-        {
-            get { return Options.Name; }
-        }
+        public string Name => Options.Name;
 
         protected internal ILoggerFactory LoggerFactory { get; private set; }
 
@@ -148,10 +145,7 @@ namespace SuperSocket.Server
             _logger.LogError($"Session[{session.SessionID}]: session exception.", exception);
         }
 
-        public int SessionCount
-        {
-            get { return _sessionCount; }
-        }
+        public int SessionCount => _sessionCount;
 
         public async Task<bool> StartAsync()
         {

--- a/src/SuperSocket.Server/TcpSocketListener.cs
+++ b/src/SuperSocket.Server/TcpSocketListener.cs
@@ -12,8 +12,8 @@ namespace SuperSocket.Server
 
         private CancellationTokenSource _cancellationTokenSource;
         private TaskCompletionSource<bool> _stopTaskCompletionSource;
-        private Func<Socket, IChannel> _channelFactory;
-        public ListenOptions Options { get; private set; }
+        private readonly Func<Socket, IChannel> _channelFactory;
+        public ListenOptions Options { get; }
 
         public TcpSocketListener(ListenOptions options, Func<Socket, IChannel> channelFactory)
         {
@@ -23,7 +23,7 @@ namespace SuperSocket.Server
 
         private IPEndPoint GetListenEndPoint(string ip, int port)
         {
-            var ipAddress = IPAddress.None;
+            IPAddress ipAddress;
 
             if ("any".Equals(ip, StringComparison.OrdinalIgnoreCase))
             {
@@ -97,10 +97,7 @@ namespace SuperSocket.Server
         {
             var handler = NewClientAccepted;
 
-            if (handler == null)
-                return;
-
-            handler(this, _channelFactory(socket));
+            handler?.Invoke(this, _channelFactory(socket));
         }
 
         public Task StopAsync()

--- a/src/SuperSocket.Server/TcpSocketListener.cs
+++ b/src/SuperSocket.Server/TcpSocketListener.cs
@@ -1,11 +1,6 @@
 using System;
-using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using System.Buffers;
-using SuperSocket;
-using SuperSocket.Channel;
-using SuperSocket.ProtoBase;
 using System.Threading;
 using System.Net;
 

--- a/src/SuperSocket.Server/TcpSocketListenerFactory.cs
+++ b/src/SuperSocket.Server/TcpSocketListenerFactory.cs
@@ -1,9 +1,3 @@
-using System;
-using System.IO.Pipelines;
-using System.Net.Sockets;
-using System.Threading.Tasks;
-using System.Buffers;
-using SuperSocket;
 using SuperSocket.Channel;
 using SuperSocket.ProtoBase;
 

--- a/test/Test/ConfigTest.cs
+++ b/test/Test/ConfigTest.cs
@@ -1,12 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO.Pipelines;
-using System.Net;
-using System.Net.Sockets;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using SuperSocket;
 using SuperSocket.ProtoBase;
 using SuperSocket.Server;
 using Xunit;

--- a/test/Test/FixedHeaderProtocolTest.cs
+++ b/test/Test/FixedHeaderProtocolTest.cs
@@ -16,9 +16,9 @@ namespace Tests
 
         }
 
-        class MyFixedHeaderPiplelineFilter : FixedHeaderPipelineFilter<TextPackageInfo>
+        class MyFixedHeaderPipelineFilter : FixedHeaderPipelineFilter<TextPackageInfo>
         {
-            public MyFixedHeaderPiplelineFilter()
+            public MyFixedHeaderPipelineFilter()
                 : base(4)
             {
 
@@ -41,9 +41,9 @@ namespace Tests
             return sourceLine.Length.ToString().PadLeft(4) + sourceLine;
         }
 
-        protected override SuperSocketServer CreateSevrer()
+        protected override SuperSocketServer CreateServer()
         {
-            return CreateSocketServer<TextPackageInfo, MyFixedHeaderPiplelineFilter>(packageHandler: async (s, p) =>
+            return CreateSocketServer<TextPackageInfo, MyFixedHeaderPipelineFilter>(packageHandler: async (s, p) =>
             {
                 await s.Channel.SendAsync(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(p.Text + "\r\n")));
             });

--- a/test/Test/FixedHeaderProtocolTest.cs
+++ b/test/Test/FixedHeaderProtocolTest.cs
@@ -1,16 +1,6 @@
 using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Net.Sockets;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using SuperSocket.ProtoBase;
 using SuperSocket.Server;
 using Xunit;

--- a/test/Test/FixedSizeProtocolTest.cs
+++ b/test/Test/FixedSizeProtocolTest.cs
@@ -16,9 +16,9 @@ namespace Tests
 
         }
 
-        class MyFixedSizePiplelineFilter : FixedSizePipelineFilter<TextPackageInfo>
+        class MyFixedSizePipelineFilter : FixedSizePipelineFilter<TextPackageInfo>
         {
-            public MyFixedSizePiplelineFilter()
+            public MyFixedSizePipelineFilter()
                 : base(36)
             {
 
@@ -35,9 +35,9 @@ namespace Tests
             return sourceLine;
         }
 
-        protected override SuperSocketServer CreateSevrer()
+        protected override SuperSocketServer CreateServer()
         {
-            return CreateSocketServer<TextPackageInfo, MyFixedSizePiplelineFilter>(packageHandler: async (s, p) =>
+            return CreateSocketServer<TextPackageInfo, MyFixedSizePipelineFilter>(packageHandler: async (s, p) =>
             {
                 await s.Channel.SendAsync(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(p.Text + "\r\n")));
             });

--- a/test/Test/ProtocolTestBase.cs
+++ b/test/Test/ProtocolTestBase.cs
@@ -13,15 +13,15 @@ namespace Tests
 {
     public abstract class ProtocolTestBase : TestBase, IDisposable
     {
-        SuperSocketServer _server;
+        readonly SuperSocketServer _server;
 
         protected ProtocolTestBase(ITestOutputHelper outputHelper) : base(outputHelper)
         {
-            _server = CreateSevrer();
+            _server = CreateServer();
             _server.StartAsync().Wait();
         }
 
-        protected abstract SuperSocketServer CreateSevrer();
+        protected abstract SuperSocketServer CreateServer();
 
         protected Socket CreateClient()
         {

--- a/test/Test/TerminatorProtocolTest.cs
+++ b/test/Test/TerminatorProtocolTest.cs
@@ -17,15 +17,15 @@ namespace Tests
 
         protected override string CreateRequest(string sourceLine)
         {
-            return string.Format("{0}##", sourceLine);
+            return $"{sourceLine}##";
         }
 
-        protected override SuperSocketServer CreateSevrer()
+        protected override SuperSocketServer CreateServer()
         {
-            return CreateSocketServer<TextPackageInfo>(packageHandler: async (s, p) =>
+            return CreateSocketServer(packageHandler: async (s, p) =>
             {
                 await s.Channel.SendAsync(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(p.Text + "\r\n")));
-            }, pipeLineFilterFactory: (x) => new TerminatorTextPipelineFilter(new byte[] { (byte)'#', (byte)'#' }));
+            }, pipeLineFilterFactory: (x) => new TerminatorTextPipelineFilter(new[] { (byte)'#', (byte)'#' }));
         }
     }
 }

--- a/test/Test/TestBase.cs
+++ b/test/Test/TestBase.cs
@@ -29,13 +29,13 @@ namespace Tests
             where TPackageInfo : class
             where TPipelineFilter : IPipelineFilter<TPackageInfo>, new()
         {
-            return CreateSocketServer<TPackageInfo>(configDict, packageHandler,  new DefaultPipelineFilterFactory<TPackageInfo, TPipelineFilter>());
+            return CreateSocketServer(configDict, packageHandler,  new DefaultPipelineFilterFactory<TPackageInfo, TPipelineFilter>());
         }
 
         protected SuperSocketServer CreateSocketServer<TPackageInfo>(Dictionary<string, string> configDict = null, Action<IAppSession, TPackageInfo> packageHandler = null, Func<object, IPipelineFilter<TPackageInfo>> pipeLineFilterFactory = null)
             where TPackageInfo : class
         {
-            return CreateSocketServer<TPackageInfo>(configDict, packageHandler,  new DelegatePipelineFilterFactory<TPackageInfo>(pipeLineFilterFactory));
+            return CreateSocketServer(configDict, packageHandler,  new DelegatePipelineFilterFactory<TPackageInfo>(pipeLineFilterFactory));
         }
 
         protected SuperSocketServer CreateSocketServer<TPackageInfo>(Dictionary<string, string> configDict = null, Action<IAppSession, TPackageInfo> packageHandler = null, IPipelineFilterFactory<TPackageInfo> filterFactory = null)
@@ -65,7 +65,7 @@ namespace Tests
             var serverOptions = new ServerOptions();
             config.GetSection("serverOptions").Bind(serverOptions);
 
-            Assert.True(server.Configure<TPackageInfo>(serverOptions, services, packageHandler: packageHandler, pipelineFilterFactory: filterFactory));
+            Assert.True(server.Configure(serverOptions, services, packageHandler: packageHandler, pipelineFilterFactory: filterFactory));
 
             return server;
         }

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Net.Sockets;
-using System.Buffers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
Hi Kerry,
     I have tried to fix as many problems as I can.
    
But these are still some problems, I am not sure how to fix it.
1.Delegate subtraction has unpredictable result
SuperSocket\src\SuperSocket.Channel\ChannelBase.cs
remove => _packageReceived -= value;
remove => _closed -= value;
https://stackoverflow.com/questions/11180068/delegate-subtraction-has-unpredictable-result-in-resharper-c

2.Virtual member call in a constructor
SuperSocket\test\Test\ProtocolTestBase.cs
https://stackoverflow.com/questions/119506/virtual-member-call-in-a-constructor

3.wrong namespaces
for example, classes in SuperSocket.Primitives project are under SuperSocket namespace instead of SuperSocket.Primitives, I am not sure if you want me to fix it.

4.some unused properties or method



