### PR TITLE
override the ToString method for TcpSocketListener

### DIFF
--- a/src/SuperSocket.Primitives/ListenOptions.cs
+++ b/src/SuperSocket.Primitives/ListenOptions.cs
@@ -11,5 +11,10 @@ namespace SuperSocket
         public int BackLog { get; set; }
 
         public bool NoDelay { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Ip)} = {Ip},{nameof(Port)} = {Port},{nameof(Path)} = {Path},{nameof(BackLog)} = {BackLog},{nameof(NoDelay)} = {NoDelay}";
+        }
     }
 }

--- a/src/SuperSocket.Server/TcpSocketListener.cs
+++ b/src/SuperSocket.Server/TcpSocketListener.cs
@@ -109,5 +109,10 @@ namespace SuperSocket.Server
             
             return _stopTaskCompletionSource.Task;
         }
+
+        public override string ToString()
+        {
+            return Options.ToString();
+        }
     }
 }


### PR DESCRIPTION
We have the following code in SuperSocket\src\SuperSocket.Server\SuperSocketServer.cs
```C#
  _logger.LogError(e, $"Failed to bind the transport {listener}.");
```
It means we need record the information of ListenOptions.