### PR TITLE
Websocketserver broadcast send raw data

### DIFF
--- a/Protocols/WebSocket/WebSocketServer.cs
+++ b/Protocols/WebSocket/WebSocketServer.cs
@@ -127,7 +127,7 @@ namespace SuperSocket.WebSocket
         public WebSocketServer(ISubProtocol<TWebSocketSession> subProtocol)
             : this(new List<ISubProtocol<TWebSocketSession>> { subProtocol })
         {
-            
+
         }
 
         /// <summary>
@@ -244,7 +244,7 @@ namespace SuperSocket.WebSocket
                 {
                     string originalProtocolName = protocolConfig.Name;
                     string protocolName;
-                    
+
                     ISubProtocol<TWebSocketSession> subProtocolInstance;
 
                     if (!string.IsNullOrEmpty(originalProtocolName))
@@ -328,7 +328,7 @@ namespace SuperSocket.WebSocket
                     return false;
                 }
             }
-            
+
             return true;
         }
 
@@ -652,7 +652,7 @@ namespace SuperSocket.WebSocket
             var commands = new List<ICommand<TWebSocketSession, IWebSocketFragment>>
                 {
                     new HandShake<TWebSocketSession>(),
-                    new Text<TWebSocketSession>(),  
+                    new Text<TWebSocketSession>(),
                     new Binary<TWebSocketSession>(),
                     new Close<TWebSocketSession>(),
                     new Ping<TWebSocketSession>(),
@@ -772,7 +772,8 @@ namespace SuperSocket.WebSocket
 
             try
             {
-                sendOk = session.TrySendRawData(param.Data);
+                session.SendRawData(param.Data);
+                sendOk = true;
             }
             catch (Exception e)
             {

--- a/Protocols/WebSocket/WebSocketSession.cs
+++ b/Protocols/WebSocket/WebSocketSession.cs
@@ -475,6 +475,15 @@ namespace SuperSocket.WebSocket
         }
 
         /// <summary>
+        /// Sends raw data segments.
+        /// </summary>
+        /// <param name="segments">The segments.</param>
+        internal void SendRawData(IList<ArraySegment<byte>> segments)
+        {
+            base.Send(segments);
+        }
+
+        /// <summary>
         /// Tries the send raw data segments.
         /// </summary>
         /// <param name="segments">The segments.</param>


### PR DESCRIPTION
Wouldn't it be better if WebSocketServer.Broadcast internally used a new method
void WebSocketSession<TWebSocketSession>.SendRawData(IList<ArraySegment<byte>> segments)
instead of the current
bool WebSocketSession<TWebSocketSession>.TrySendRawData(IList<ArraySegment<byte>> segments)?