### PR TITLE
[Fixing] avoid dotnet pack failed

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="Dependencies.props" />
   <PropertyGroup>
     <VersionPrefix>2.0.0-preview3</VersionPrefix>
-    <NrtRevisionFormat>2.0.0-preview3({chash})</NrtRevisionFormat>
+    <NrtRevisionFormat>2.0.0-preview3-{chash}</NrtRevisionFormat>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
make the product version matches Format: Alphanumberic (+ hyphen) string: [0-9A-Za-z-]* to avoid dotnet pack failed error