### PR TITLE
Added missing JsonSerializerOptions

### DIFF
--- a/src/SuperSocket.Command/JsonCommand.cs
+++ b/src/SuperSocket.Command/JsonCommand.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using System.Text.Json;
 using SuperSocket.ProtoBase;
-
 
 namespace SuperSocket.Command
 {
@@ -34,7 +32,7 @@ namespace SuperSocket.Command
 
         protected virtual TJsonObject Deserialize(string content)
         {
-            return JsonSerializer.Deserialize<TJsonObject>(content);
+            return JsonSerializer.Deserialize<TJsonObject>(content, JsonSerializerOptions);
         }
     }
 


### PR DESCRIPTION
While reading through the code I discovered that the `JsonCommand<TJsonObject>` didn't get its `JsonSerializerOptions` applied when serializing JSON.