### PR TITLE
Reduce max packet length to use buffer pools efficiently

### DIFF
--- a/src/SuperSocket.Channel/ChannelOptions.cs
+++ b/src/SuperSocket.Channel/ChannelOptions.cs
@@ -8,8 +8,8 @@ namespace SuperSocket.Channel
 {
     public class ChannelOptions
     {
-        // 4M by default
-        public int MaxPackageLength { get; set; } = 1024 * 1024 * 4;
+        // 1M by default
+        public int MaxPackageLength { get; set; } = 1024 * 1024;
         
         // 4k by default
         public int ReceiveBufferSize { get; set; } = 1024 * 4;


### PR DESCRIPTION
My proposal based on the discussion in https://github.com/kerryjiang/SuperSocket/issues/452