### PR TITLE
Add GZip Support.

### DIFF
--- a/src/SuperSocket.Channel/GZipReadWriteStream.cs
+++ b/src/SuperSocket.Channel/GZipReadWriteStream.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Buffers;
+using System.Threading.Tasks;
+using System.IO;
+using System.Net.Sockets;
+using System.Net;
+using System.Threading;
+using SuperSocket.ProtoBase;
+using System.IO.Compression;
+
+namespace SuperSocket.Channel
+{
+    public class GZipReadWriteStream : Stream
+    {
+        public Stream BaseStream { get; }
+        GZipStream readStream = null;
+        GZipStream writeStream = null;
+        public GZipReadWriteStream(Stream stream, bool leaveOpen)
+        {
+            BaseStream = stream;
+            readStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen);
+            writeStream = new GZipStream(stream, CompressionMode.Compress, leaveOpen);
+        }
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush()
+        {
+            writeStream.Flush();
+        }
+
+        [Obsolete("please don't use this method to avoid blocking.use ReadAsync instead.")]
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return readStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            writeStream.Write(buffer, offset, count);
+        }
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            writeStream.Write(buffer);
+        }
+        public override int Read(Span<byte> buffer)
+        {
+            return readStream.Read(buffer);
+        }
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return readStream.BeginRead(buffer, offset, count, callback, state);
+        }
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return writeStream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override void Close()
+        {
+            readStream.Close();
+            writeStream.Close();
+        }
+
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            readStream.CopyTo(destination, bufferSize);
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return readStream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+
+        public override async ValueTask DisposeAsync()
+        {
+            await readStream.DisposeAsync();
+            await writeStream.DisposeAsync();
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return readStream.EndRead(asyncResult);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            writeStream.EndWrite(asyncResult);
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return writeStream.FlushAsync(cancellationToken);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return readStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            return readStream.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override int ReadByte()
+        {
+            return readStream.ReadByte();
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return writeStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            return writeStream.WriteAsync(buffer, cancellationToken);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            writeStream.WriteByte(value);
+        }
+
+        public override bool CanTimeout => BaseStream.CanTimeout;
+
+        public override int ReadTimeout { get => BaseStream.ReadTimeout; set => BaseStream.ReadTimeout = value; }
+        public override int WriteTimeout { get => BaseStream.WriteTimeout; set => BaseStream.WriteTimeout = value; }
+    }
+}

--- a/src/SuperSocket.Channel/GZipReadWriteStream.cs
+++ b/src/SuperSocket.Channel/GZipReadWriteStream.cs
@@ -36,10 +36,12 @@ namespace SuperSocket.Channel
             writeStream.Flush();
         }
 
-        [Obsolete("please don't use this method to avoid blocking.use ReadAsync instead.")]
         public override int Read(byte[] buffer, int offset, int count)
         {
-            return readStream.Read(buffer, offset, count);
+            var task = readStream.ReadAsync(buffer, offset, count, CancellationToken.None) ;
+            task.ConfigureAwait(false);
+            task.Wait();
+            return task.Result;
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/SuperSocket.Client/ConnectState.cs
+++ b/src/SuperSocket.Client/ConnectState.cs
@@ -38,11 +38,11 @@ namespace SuperSocket.Client
 
             if (stream != null)
             {
-                return new StreamPipeChannel<TReceivePackage>(stream , socket.RemoteEndPoint, socket.LocalEndPoint, pipelineFilter, channelOptions);
+                return new StreamPipeChannel<TReceivePackage>(stream, socket.RemoteEndPoint, socket.LocalEndPoint, pipelineFilter, channelOptions);
             }
             else
             {
-                return new TcpPipeChannel<TReceivePackage>(socket, pipelineFilter, channelOptions);
+                return new StreamPipeChannel<TReceivePackage>(new NetworkStream(socket, true), socket.RemoteEndPoint, socket.LocalEndPoint, pipelineFilter, channelOptions);
             }
         }
     }

--- a/src/SuperSocket.Client/GZipConnector.cs
+++ b/src/SuperSocket.Client/GZipConnector.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Options;
+using SuperSocket.Channel;
+using System;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SuperSocket.Client
+{
+    public class GZipConnector : ConnectorBase
+    {
+        public GZipConnector(IConnector nextConnector)
+            : base(nextConnector)
+        {
+        }
+        public GZipConnector()
+            :base()
+        {
+        }
+
+        protected override async ValueTask<ConnectState> ConnectAsync(EndPoint remoteEndPoint, ConnectState state, CancellationToken cancellationToken)
+        {
+            var stream = state.Stream;
+
+            if (stream == null)
+                throw new Exception("Stream from previous connector is null.");
+
+            try
+            {
+                var gzipStream = new GZipReadWriteStream(stream, true);
+                state.Stream = gzipStream;
+                return state;
+            }
+            catch (Exception e)
+            {
+                return new ConnectState
+                {
+                    Result = false,
+                    Exception = e
+                };
+            }
+        }
+    }
+}

--- a/src/SuperSocket.Client/IEasyClient.cs
+++ b/src/SuperSocket.Client/IEasyClient.cs
@@ -24,6 +24,8 @@ namespace SuperSocket.Client
 
         SecurityOptions Security { get; set; }
 
+        bool GZipEnable { get; set; }
+
         void StartReceive();
 
         ValueTask SendAsync(ReadOnlyMemory<byte> data);

--- a/src/SuperSocket.Client/SocketConnector.cs
+++ b/src/SuperSocket.Client/SocketConnector.cs
@@ -37,7 +37,7 @@ namespace SuperSocket.Client
         protected override async ValueTask<ConnectState> ConnectAsync(EndPoint remoteEndPoint, ConnectState state, CancellationToken cancellationToken)
         {
             var socket = new Socket(remoteEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            
+
             try
             {
                 var localEndPoint = LocalEndPoint;
@@ -45,11 +45,17 @@ namespace SuperSocket.Client
                 if (localEndPoint != null)
                 {
                     socket.ExclusiveAddressUse = false;
-                    socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);             
+                    socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
                     socket.Bind(localEndPoint);
                 }
 
                 await socket.ConnectAsync(remoteEndPoint);
+                return new ConnectState
+                {
+                    Result = true,
+                    Socket = socket,
+                    Stream = new NetworkStream(socket, System.IO.FileAccess.ReadWrite, true)
+                };
             }
             catch (Exception e)
             {
@@ -60,11 +66,6 @@ namespace SuperSocket.Client
                 };
             }
 
-            return new ConnectState
-            {
-                Result = true,
-                Socket = socket
-            };            
         }
     }
 }

--- a/src/SuperSocket.Client/SslStreamConnector.cs
+++ b/src/SuperSocket.Client/SslStreamConnector.cs
@@ -39,20 +39,20 @@ namespace SuperSocket.Client
                 Options.TargetHost = targetHost;
             }
 
-            var socket = state.Socket;
+            var stream = state.Stream;
 
-            if (socket == null)
+            if (stream == null)
                 throw new Exception("Socket from previous connector is null.");
-            
+
             try
             {
-                var stream = new SslStream(new NetworkStream(socket, true), false);
-                await stream.AuthenticateAsClientAsync(Options, cancellationToken);
+                var sslStream = new SslStream(stream, false);
+                await sslStream.AuthenticateAsClientAsync(Options, cancellationToken);
 
                 if (cancellationToken.IsCancellationRequested)
                     return ConnectState.CancelledState;
 
-                state.Stream = stream;
+                state.Stream = sslStream;
                 return state;
             }
             catch (Exception e)

--- a/src/SuperSocket.Primitives/ListenOptions.cs
+++ b/src/SuperSocket.Primitives/ListenOptions.cs
@@ -13,6 +13,7 @@ namespace SuperSocket
         public int BackLog { get; set; }
 
         public bool NoDelay { get; set; }
+        public bool GZipEnable { get; set; }
 
         public SslProtocols Security { get; set; }
 

--- a/test/SuperSocket.Tests/ClientTest.cs
+++ b/test/SuperSocket.Tests/ClientTest.cs
@@ -42,6 +42,8 @@ namespace SuperSocket.Tests
         [Trait("Category", "Client.TestEcho")]
         [InlineData(typeof(RegularHostConfigurator), false)]
         [InlineData(typeof(SecureHostConfigurator), false)]
+        [InlineData(typeof(GzipHostConfigurator), false)]
+        [InlineData(typeof(GzipSecureHostConfigurator), false)]
         [InlineData(typeof(RegularHostConfigurator), true)]
         public async Task TestEcho(Type hostConfiguratorType, bool clientReadAsDemand)
         {
@@ -140,6 +142,8 @@ namespace SuperSocket.Tests
         [Theory]
         [InlineData(typeof(RegularHostConfigurator))]
         [InlineData(typeof(SecureHostConfigurator))]
+        [InlineData(typeof(GzipHostConfigurator))]
+        [InlineData(typeof(GzipSecureHostConfigurator))]
         public async Task TestCommandLine(Type hostConfiguratorType)
         {
             var hostConfigurator = CreateObject<IHostConfigurator>(hostConfiguratorType);

--- a/test/SuperSocket.Tests/GzipHostConfigurator.cs
+++ b/test/SuperSocket.Tests/GzipHostConfigurator.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SuperSocket;
+using SuperSocket.Channel;
+using SuperSocket.Client;
+using SuperSocket.ProtoBase;
+
+namespace SuperSocket.Tests
+{
+    public class GzipHostConfigurator : TcpHostConfigurator
+    {
+        public GzipHostConfigurator()
+        {
+            WebSocketSchema = "wss";
+            IsSecure = false;
+        }
+
+        public override void Configure(ISuperSocketHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices((ctx, services) =>
+            {
+                services.Configure<ServerOptions>((options) =>
+                {
+                    var listener = options.Listeners[0];
+                    listener.GZipEnable = true;
+
+                });
+            });
+
+            base.Configure(hostBuilder);
+        }
+        public override async ValueTask<Stream> GetClientStream(Socket socket)
+        {
+            Stream stream = new GZipReadWriteStream(new NetworkStream(socket,false), true);
+            return stream;
+        }
+
+        protected virtual SslProtocols GetServerEnabledSslProtocols()
+        {
+            return SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11;
+        }
+
+        protected virtual SslProtocols GetClientEnabledSslProtocols()
+        {
+            return SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11;
+        }
+
+        public override IEasyClient<TPackageInfo> ConfigureEasyClient<TPackageInfo>(IEasyClient<TPackageInfo> client) where TPackageInfo : class
+        {
+            client.GZipEnable = true;
+            return client;
+        }
+    }
+
+}

--- a/test/SuperSocket.Tests/GzipSecureHostConfigurator.cs
+++ b/test/SuperSocket.Tests/GzipSecureHostConfigurator.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SuperSocket;
+using SuperSocket.Channel;
+using SuperSocket.Client;
+using SuperSocket.ProtoBase;
+
+namespace SuperSocket.Tests
+{
+    public class GzipSecureHostConfigurator : TcpHostConfigurator
+    {
+        public GzipSecureHostConfigurator()
+        {
+            WebSocketSchema = "wss";
+            IsSecure = true;
+        }
+
+        public override void Configure(ISuperSocketHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices((ctx, services) =>
+            {
+                services.Configure<ServerOptions>((options) =>
+                {
+                    var listener = options.Listeners[0];
+                    listener.GZipEnable = true;
+
+                    if (listener.Security == SslProtocols.None)
+                        listener.Security = GetServerEnabledSslProtocols();
+
+                    listener.CertificateOptions = new CertificateOptions
+                    {
+                        FilePath = "supersocket.pfx",
+                        Password = "supersocket"
+                    };
+                });
+            });
+
+            base.Configure(hostBuilder);
+        }
+        public override async ValueTask<Stream> GetClientStream(Socket socket)
+        {
+            var stream = new SslStream(new DerivedNetworkStream(socket), false);
+            var options = new SslClientAuthenticationOptions();
+            options.TargetHost = "supersocket";
+            options.EnabledSslProtocols = GetClientEnabledSslProtocols();
+            options.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+            await stream.AuthenticateAsClientAsync(options);
+            var zipStream = new GZipReadWriteStream(stream, true);
+            return zipStream;
+        }
+
+        protected virtual SslProtocols GetServerEnabledSslProtocols()
+        {
+            return SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11;
+        }
+
+        protected virtual SslProtocols GetClientEnabledSslProtocols()
+        {
+            return SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11;
+        }
+
+        public override IEasyClient<TPackageInfo> ConfigureEasyClient<TPackageInfo>(IEasyClient<TPackageInfo> client) where TPackageInfo : class
+        {
+            client.GZipEnable = true;
+            client.Security = new SecurityOptions
+            {
+                TargetHost = "supersocket",
+                EnabledSslProtocols = GetClientEnabledSslProtocols(),
+                RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true
+            };
+
+            return client;
+        }
+    }
+
+}

--- a/test/SuperSocket.Tests/ProtocolTestBase.cs
+++ b/test/SuperSocket.Tests/ProtocolTestBase.cs
@@ -251,7 +251,7 @@ namespace SuperSocket.Tests
 
                         for (var i = 0; i < size; i++)
                         {
-                            var receivedLine = reader.ReadLine();
+                            var receivedLine = await reader.ReadLineAsync();
                             Assert.Equal(lines[i], receivedLine);
                         }
                     }


### PR DESCRIPTION
通过使用GZipStream封装了一层GzipReadWriteStream来使链路压缩。

原理与SslStream的处理类似
接收： networkStream=>sslStream=>GzipStream解压
发送：GzipStream压缩=>sslStream=>networkStream

唯一一点不够完美的是
GzipStream使用Read读取内容时，会出现有数据了但仍不返回的现象。使用ReadAsync等异步方法接受时OK的，所以GzipReadWriteStream中将改方法设置为Obsolete。

会导致的结果是某些TestCase中直接使用Stream封装成TextReader来读取，导致读不到东西，使用EasyClient是没有这个问题的。
