### PR TITLE
Expose the remote cert for SslStream based channels

### DIFF
--- a/src/SuperSocket.Channel/IChannelWithRemoteCertificate.cs
+++ b/src/SuperSocket.Channel/IChannelWithRemoteCertificate.cs
@@ -1,0 +1,9 @@
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace SuperSocket.Channel
+{
+    public interface IChannelWithRemoteCertificate
+    {
+        X509Certificate RemoteCertificate { get; }
+    }
+}

--- a/src/SuperSocket.Channel/SslStreamPipeChannel.cs
+++ b/src/SuperSocket.Channel/SslStreamPipeChannel.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using SuperSocket.ProtoBase;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace SuperSocket.Channel
+{
+    public class SslStreamPipeChannel<TPackageInfo> : StreamPipeChannel<TPackageInfo>, IChannelWithRemoteCertificate
+    {
+        public SslStreamPipeChannel(SslStream stream, EndPoint remoteEndPoint, IPipelineFilter<TPackageInfo> pipelineFilter, ChannelOptions options)
+            : this(stream, remoteEndPoint, null, pipelineFilter, options)
+        {
+        }
+
+        public SslStreamPipeChannel(SslStream stream, EndPoint remoteEndPoint, EndPoint localEndPoint, IPipelineFilter<TPackageInfo> pipelineFilter, ChannelOptions options)
+            : base(stream, remoteEndPoint, localEndPoint, pipelineFilter, options)
+        {
+            if (stream.IsAuthenticated || stream.IsMutuallyAuthenticated)
+            {
+                RemoteCertificate = stream.RemoteCertificate;
+            }
+        }
+
+        public X509Certificate RemoteCertificate { get; }
+    }
+}

--- a/src/SuperSocket.Server/TcpChannelCreatorFactory.cs
+++ b/src/SuperSocket.Server/TcpChannelCreatorFactory.cs
@@ -114,7 +114,7 @@ namespace SuperSocket.Server
 
                     var stream = new SslStream(new NetworkStream(s, true), false);
                     await stream.AuthenticateAsServerAsync(authOptions, CancellationToken.None).ConfigureAwait(false);
-                    return new StreamPipeChannel<TPackageInfo>(stream, s.RemoteEndPoint, s.LocalEndPoint, filterFactory.Create(s), channelOptions);
+                    return new SslStreamPipeChannel<TPackageInfo>(stream, s.RemoteEndPoint, s.LocalEndPoint, filterFactory.Create(s), channelOptions);
                 });
 
                 return new TcpChannelCreator(options, channelFactory, channelFactoryLogger);


### PR DESCRIPTION
This is needed to allow authorization based on the identity of the certificate when requesting/accepting a client certificate.

I went with a new StreamPipeChannel class (`SslStreamPipeChannel`) to avoid breaking anything, and expose the new property via an interface (`IChannelWithRemoteCertificate`), as inspired by `IChannelWithSessionIdentifier`.

This means that in any piece of code that has access to the session, we can look at the remote cert if we want like so:

`if (session.Channel is IChannelWithRemoteCertificate channelWithRemoteCertificate)`