### PR TITLE
Cancellation token should be respected when calling ConnectAsync

### DIFF
--- a/src/SuperSocket.Client/SocketConnector.cs
+++ b/src/SuperSocket.Client/SocketConnector.cs
@@ -48,8 +48,11 @@ namespace SuperSocket.Client
                     socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);             
                     socket.Bind(localEndPoint);
                 }
-
+#if NET5_0
+                await socket.ConnectAsync(remoteEndPoint, cancellationToken);
+#else
                 await socket.ConnectAsync(remoteEndPoint);
+#endif
             }
             catch (Exception e)
             {

--- a/src/SuperSocket.Client/SocketConnector.cs
+++ b/src/SuperSocket.Client/SocketConnector.cs
@@ -37,7 +37,7 @@ namespace SuperSocket.Client
         protected override async ValueTask<ConnectState> ConnectAsync(EndPoint remoteEndPoint, ConnectState state, CancellationToken cancellationToken)
         {
             var socket = new Socket(remoteEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            
+
             try
             {
                 var localEndPoint = LocalEndPoint;
@@ -45,13 +45,24 @@ namespace SuperSocket.Client
                 if (localEndPoint != null)
                 {
                     socket.ExclusiveAddressUse = false;
-                    socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);             
+                    socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
                     socket.Bind(localEndPoint);
                 }
 #if NET5_0
                 await socket.ConnectAsync(remoteEndPoint, cancellationToken);
 #else
-                await socket.ConnectAsync(remoteEndPoint);
+                Task result = socket.ConnectAsync(remoteEndPoint);               
+                int index = Task.WaitAny(new[] { result }, cancellationToken);
+                var connected = socket.Connected;
+                if (!connected)
+                {
+                    socket.Close();
+
+                    return new ConnectState
+                    {
+                        Result = false,
+                    };
+                }
 #endif
             }
             catch (Exception e)

--- a/src/SuperSocket.Client/SocketConnector.cs
+++ b/src/SuperSocket.Client/SocketConnector.cs
@@ -48,7 +48,7 @@ namespace SuperSocket.Client
                     socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
                     socket.Bind(localEndPoint);
                 }
-#if NET5_0
+#if NET5_0_OR_GREATER
                 await socket.ConnectAsync(remoteEndPoint, cancellationToken);
 #else
                 Task result = socket.ConnectAsync(remoteEndPoint);               

--- a/test/SuperSocket.Tests/ClientTest.cs
+++ b/test/SuperSocket.Tests/ClientTest.cs
@@ -185,6 +185,7 @@ namespace SuperSocket.Tests
 
             Assert.False(hasWaitedLongerThanTheCancellationToken);
         }
+
         [Theory]
         [InlineData(typeof(RegularHostConfigurator))]
         [InlineData(typeof(SecureHostConfigurator))]


### PR DESCRIPTION
You can pass CancellationToken to IEasyClient.ConnectAsync method. But it's not respected. 
EasyClient will wait a lot longer than what I specified in CancellationToken.
As far as I checked SocketConnector is not doing anything with CancellationToken.

In this PR I passed cancellation token to the Socket which is used internally. 
Unfortunately, netstandard2.1 doesnt accept CancellationToken as a parameter so I added conditional compilation and implemented special code for netstandard to handle this scenario.
