### PR TITLE
HandshakeValidator检验不通过，握手失败时，TcpPipeChannel.PipelineFilter.Context，W…

### DIFF
--- a/src/SuperSocket.Channel/TcpPipeChannel.cs
+++ b/src/SuperSocket.Channel/TcpPipeChannel.cs
@@ -76,6 +76,11 @@ namespace SuperSocket.Channel
 
         protected override void Close()
         {
+            if (this is IPipeChannel channel)
+            {
+                channel.PipelineFilter?.Reset();
+            }
+
             var socket = _socket;
 
             if (socket == null)

--- a/src/SuperSocket.ProtoBase/PackagePartsPipelineFilter.cs
+++ b/src/SuperSocket.ProtoBase/PackagePartsPipelineFilter.cs
@@ -53,6 +53,8 @@ namespace SuperSocket.ProtoBase
         {
             CurrentPackage = null;
             _currentPartReader = null;
+            Context = null;
+            NextFilter = null;
         }
 
         public object Context { get; set; }

--- a/src/SuperSocket.WebSocket/WebSocketPipelineFilter.cs
+++ b/src/SuperSocket.WebSocket/WebSocketPipelineFilter.cs
@@ -138,7 +138,9 @@ namespace SuperSocket.WebSocket
 
         public void Reset()
         {
-            
+            NextFilter = null;
+            Context = null;
+            GC.Collect();
         }
 
         public object Context { get; set; }


### PR DESCRIPTION
…ebSocketSession交叉引用，导致gc无法回收，内存溢出问题修复